### PR TITLE
package recognition issue

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,9 +39,8 @@ dependencies = [
 requires = ["setuptools", "wheel"]
 build-backend = "setuptools.build_meta"
 
-[tool.setuptools.packages.find]
-where = ["MarchingNumPy", "MarchingCuPy"]
-include = ["MarchingNumPy*", "MarchingCuPy*"]
+[tool.setuptools]  
+packages = ["MarchingNumPy", "MarchingCuPy"]  
 
 [tool.mypy]
 


### PR DESCRIPTION
### fix: make packages explicitly discoverable by pip

The current pyproject.toml incorrectly specifies package paths.

#### Changes:
```diff
- [tool.setuptools.packages.find]
- where = ['MarchingNumPy', 'MarchingCuPy']
- include = ['MarchingNumPy*', 'MarchingCuPy*']

+ [tool.setuptools]
+ packages = ['MarchingNumPy', 'MarchingCuPy']

# Alternative

+ [tool.setuptools.packages.find]
+ where = ['.']
+ include = ['MarchingNumPy*', 'MarchingCuPy*']
```
